### PR TITLE
Add passwordless ssh from all hosts to all hosts

### DIFF
--- a/ansible-playbook-base/roles/passwdless-ssh-setup/tasks/main.yml
+++ b/ansible-playbook-base/roles/passwdless-ssh-setup/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+# This task determines the number of bricks needed and configures
+# the bricks on the respective server hosts
+
+- name: Generate ssh keys
+  user:
+    name: root
+    generate_ssh_key: yes
+    ssh_key_file: .ssh/id_rsa
+
+- name: Copy ssh public key
+  shell: cat ~/.ssh/id_rsa.pub
+  register: ssh_keys
+
+# TODO: Deply server host keys in servers only and same with client
+- name: Deploy keys on all hosts
+  authorized_key: user=root key="{{ item[0] }}"
+  delegate_to: "{{ item[1] }}"
+  with_nested:
+   - "{{ ssh_keys.stdout }}"
+   - "{{groups['all']}}"

--- a/ansible-playbook-base/site.yml
+++ b/ansible-playbook-base/site.yml
@@ -42,6 +42,7 @@
   roles:
     - common
     - install-repos
+    passwdless-ssh-setup
 
 # Run gluster sources installation on the servers
 - name: Prepare Gluster servers


### PR DESCRIPTION
With this patch, ssh key is generated on all hosts (clients and servers)
and the public key is copied onto all hosts.

Signed-off-by: Poornima G <pgurusid@redhat.com>