### PR TITLE
prepare-gluster-server: Add gluster packages explicitly

### DIFF
--- a/ansible-playbook-base/roles/prepare-gluster-server/tasks/centos.yml
+++ b/ansible-playbook-base/roles/prepare-gluster-server/tasks/centos.yml
@@ -18,6 +18,19 @@
   tags:
     - packagesall
     - packagesserver
+  with_items:
+    - glusterfs
+    - glusterfs-devel
+    - glusterfs-debuginfo
+    - glusterfs-server
+    - glusterfs-client-xlators
+    - glusterfs-extra-xlators
+    - glusterfs-fuse
+    - glusterfs-api-devel
+    - glusterfs-resource-agents
+    - glusterfs-rdma
+    - glusterfs-geo-replication
+    - glusterfs-events
 
 - name: Enable glusterd service on hosts
   systemd:


### PR DESCRIPTION
Installing glusterfs* is not installing all the required packages.
As a result start of the volume is failing. Hence adding the
package names explicitly.

Signed-off-by: Poornima G <pgurusid@redhat.com>