### PR TITLE
Ignore hosts when required variables are undefined

### DIFF
--- a/ansible-playbook-base/roles/cleanup-gluster-volume/tasks/main.yml
+++ b/ansible-playbook-base/roles/cleanup-gluster-volume/tasks/main.yml
@@ -31,3 +31,7 @@
 - name: Cleanup brick directory
   file: path="{{ item.mountpoint }}/brickdir" state=absent
   with_items: "{{ storageconf[inventory_hostname].mounts }}"
+  when:
+    - storageconf[inventory_hostname] is defined
+    - storageconf[inventory_hostname].mounts is defined
+  ignore_errors: yes

--- a/ansible-playbook-base/roles/create-gluster-volume/tasks/main.yml
+++ b/ansible-playbook-base/roles/create-gluster-volume/tasks/main.yml
@@ -19,6 +19,9 @@
   set_fact:
     brickstring: "{{ brickstring | default('') }},{{ hostvars[inventory_hostname]['glusterip'] }}:{{ item.mountpoint }}/brickdir"
   loop: "{{ storageconf[inventory_hostname].mounts }}"
+  when:
+    - storageconf[inventory_hostname] is defined
+    - storageconf[inventory_hostname].mounts is defined
 
 - name: Create requested gluster volume
   delegate_to: "{{ play_hosts[0] }}"
@@ -27,7 +30,9 @@
     action:         create
     volume:         "{{ volume }}"
     bricks:         "{% for host in play_hosts %}
-                      {{ hostvars[host]['brickstring'] }};
+                      {% if hostvars[host]['brickstring'] is defined %}
+                        {{ hostvars[host]['brickstring'] }};
+                      {% endif %}
                     {% endfor %}"
     hosts:          "{{ play_hosts }}"
     replica:        "{{ replica  | default('no') }}"

--- a/ansible-playbook-base/roles/prepare-brick-mounts/tasks/main.yml
+++ b/ansible-playbook-base/roles/prepare-brick-mounts/tasks/main.yml
@@ -25,6 +25,9 @@
     action: create
     disks: "{{ item.devices[0] }}"
     options: "-f"
+  when:
+    - storageconf[inventory_hostname] is defined
+    - storageconf[inventory_hostname].pvs is defined
   with_items: "{{ storageconf[inventory_hostname].pvs }}"
   register: result
   failed_when: "result.rc != 0 and 'Physical Volume Exists' not in result.msg"
@@ -34,6 +37,9 @@
     action: create
     disks: "{{ item.pv[0] }}"
     vgname: "{{ item.vgname }}"
+  when:
+    - storageconf[inventory_hostname] is defined
+    - storageconf[inventory_hostname].vgs is defined
   with_items: "{{ storageconf[inventory_hostname].vgs }}"
   register: result
   failed_when: "result.rc != 0 and 'already exists' not in result.msg and 'is already in volume group' not in result.msg"
@@ -44,6 +50,9 @@
     lvtype: thinpool
     poolname: "{{ item.lvname }}"
     vgname: "{{ item.vg }}"
+  when:
+    - storageconf[inventory_hostname] is defined
+    - storageconf[inventory_hostname].lvpools is defined
   with_items: "{{ storageconf[inventory_hostname].lvpools }}"
 
 - name: Create LVM-LVs
@@ -54,19 +63,31 @@
     poolname: "{{ item.lvpool }}"
     lvname: "{{ item.lvname }}"
     options: "{{ item.options }}"
+  when:
+    - storageconf[inventory_hostname] is defined
+    - storageconf[inventory_hostname].lvs is defined
   with_items: "{{ storageconf[inventory_hostname].lvs }}"
 
 - name: Create filesystem
   filesystem:
     fstype: "{{ item.fstype }}"
     dev: "{{ item.lvpath }}"
+  when:
+    - storageconf[inventory_hostname] is defined
+    - storageconf[inventory_hostname].mounts is defined
   with_items: "{{ storageconf[inventory_hostname].mounts }}"
 
 - name: Create mountpoint
   file: path={{ item.mountpoint }} state=directory
+  when:
+    - storageconf[inventory_hostname] is defined
+    - storageconf[inventory_hostname].mounts is defined
   with_items: "{{ storageconf[inventory_hostname].mounts }}"
 
 - name: Mount the filesystem
   mount: name={{ item.mountpoint }} src={{ item.lvpath }}
          fstype={{ item.fstype }} state=mounted
+  when:
+    - storageconf[inventory_hostname] is defined
+    - storageconf[inventory_hostname].mounts is defined
   with_items: "{{ storageconf[inventory_hostname].mounts }}"


### PR DESCRIPTION
When using a volume that requires less bricks than hosts
in the inventory, certain plays errored out due to missing
variables. These hosts were further not considered for other
common tasks, thus causing the setup to end in errors.

This is fixed by checking for required variables for tasks
and ignoring hosts that do not have these variables defined.

Tested using a 4 server 1x3 and 2x1 volume creation, passed
with the changes in this commit.

Fixes: #44 

Signed-off-by: ShyamsundarR <srangana@redhat.com>