### PR TITLE
Add ability to run Smallfile and FIO tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ The intention of starting as above, is to kick-off regular regression runs of
 Gluster, across various supported release milestones, and to report any
 performance regressions in Gluster as the release progresses.
 
-## NOTE:
+## Using gbench for benchmarking
   - This is WIP code! has a lot of rough edges
   - If you have a setup write your own copy of ./setup-profiles/template/
     - Copy recursively the template directory into a sp-XXXX-XXXX directory
     - Edit each file as appropriate
   - Setup passwordless ssh from the host from where you will run ansible (IOW, gbench from) and the rest of the hosts in your inventory
-  - Run from the ansible-playbook-base directory: ansible-playbook -i ../setup-profiles/sp-XXXX-XXXX/secret_inventory.ini ./site.yml -e server_repo="../gluster-sources/your_repo.yml" -e client_repo="../gluster-sources/your_repo.yml" -e vc_definition="../volume-configurations/vc-0000-0010.yml" -e sc_definition="../storage-configurations/sc-0000-0010.yml"
-    - vc_definition and sc_definition are dummies for the time being but are needed varibles
+  - Run from the ansible-playbook-base directory: ansible-playbook -i ../setup-profiles/sp-XXXX-XXXX/secret_inventory.ini ./site.yml -e server_repo="../gluster-sources/your_repo.yml" -e client_repo="../gluster-sources/your_repo.yml" -e vc_definition="../volume-configurations/vc-0000-0010.yml" -e sc_definition="../storage-configurations/sc-0000-0010.yml" -e bt_definition="../bench-tests/bt-0000-0010.yml"
     - secret_inventory.ini is either inventory.ini for your setup or if you have hostnames to keep a secret, then the file that has the hostnames defined
   - The whole ansible playbook currently only works for CentOS and clones!
   - At the end of the run, the following changes would have taken place,
@@ -30,6 +29,8 @@ performance regressions in Gluster as the release progresses.
     - Gluster server bits installed on hosts in the "server" group (including required repositories enabled on the box)
     - Gluster client bits installed on hosts in the "client" group (including required repositories enabled on the box)
     - Gluster trusted storage pool created across the hosts in the "servers" group
+    - Provided disks to gbench cleaned up and made ready for volume configuration
+    - Provided volume created as per configuration, on a set of disks provided
 
 ## Workflow details
 

--- a/ansible-playbook-base/files/CreateBrickConfig.py
+++ b/ansible-playbook-base/files/CreateBrickConfig.py
@@ -90,9 +90,9 @@ class StorageConfiguration:
 
     supported_fstypes = {'xfs'}
     raidname_pattern = "/dev/md%d"
-    vgname_pattern = "vggbench%04d"
-    lvpname_pattern = "lvpoolgbench%04d"
-    lvname_pattern = "lvgbench%04d"
+    vgname_pattern = "vggbench_%04d_%04d"
+    lvpname_pattern = "lvpoolgbench_%04d_%04d"
+    lvname_pattern = "lvgbench_%04d_%04d"
     mount_pattern = "fsgbench%04d"
 
     def __init__(self, infile):
@@ -280,7 +280,8 @@ class HostsFacts:
                 type = rotational|nonrotational,
                 size = string,
                 disk = device,
-                host = hostname
+                host = hostname,
+                idx  = unique host index
             ],
             ...]
         """
@@ -312,7 +313,7 @@ class HostsFacts:
                 size = (ansible_device.get("size")
                         if (ansible_partition is None)
                         else ansible_partition.get("size"))
-                currentdisk = [dtype, size, device, inventory_host]
+                currentdisk = [dtype, size, device, inventory_host, idx]
                 disklist.append(currentdisk)
 
         return disklist
@@ -404,7 +405,8 @@ class SetupStorage:
                 type = rotational|nonrotational,
                 size = string,
                 disk = device,
-                host = hostname
+                host = hostname,
+                idx  = unique host index
             ],
         ...]
 
@@ -462,15 +464,15 @@ class SetupStorage:
 
         devicedefinition.append(self.sc.pvoptions)
 
-        vgname = self.sc.vgname_pattern % hostlist[1]['vgnameidx']
+        vgname = self.sc.vgname_pattern % (diskstoadd[0][4], hostlist[1]['vgnameidx'])
         devicedefinition.append(vgname)
         devicedefinition.append(self.sc.vgoptions)
 
-        lvpoolname = self.sc.lvpname_pattern % hostlist[1]['lvpoolnameidx']
+        lvpoolname = self.sc.lvpname_pattern % (diskstoadd[0][4], hostlist[1]['lvpoolnameidx'])
         devicedefinition.append(lvpoolname)
         devicedefinition.append(self.sc.lvpooloptions)
 
-        lvname = self.sc.lvname_pattern % hostlist[1]['lvnameidx']
+        lvname = self.sc.lvname_pattern % (diskstoadd[0][4], hostlist[1]['lvnameidx'])
         devicedefinition.append(lvname)
         devicedefinition.append(self.sc.lvoptions)
 

--- a/ansible-playbook-base/roles/cleanup-gluster-clients/defaults/main.yml
+++ b/ansible-playbook-base/roles/cleanup-gluster-clients/defaults/main.yml
@@ -1,2 +1,0 @@
----
-test_mountpoint: "/mnt/gbench/"

--- a/ansible-playbook-base/roles/cleanup-gluster-clients/defaults/main.yml
+++ b/ansible-playbook-base/roles/cleanup-gluster-clients/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+test_mountpoint: "/mnt/gbench/"

--- a/ansible-playbook-base/roles/cleanup-gluster-clients/tasks/main.yml
+++ b/ansible-playbook-base/roles/cleanup-gluster-clients/tasks/main.yml
@@ -2,5 +2,5 @@
 
 - name: Unmount Gluster filesystem
   mount:
-    path: "{{ test_mountpoint }}"
+    path: "{{ gbench_client_mountpoint }}"
     state: unmounted

--- a/ansible-playbook-base/roles/cleanup-gluster-clients/tasks/main.yml
+++ b/ansible-playbook-base/roles/cleanup-gluster-clients/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Unmount Gluster filesystem
+  mount:
+    path: "{{ test_mountpoint }}"
+    state: unmounted

--- a/ansible-playbook-base/roles/mount-gluster-volume/defaults/main.yml
+++ b/ansible-playbook-base/roles/mount-gluster-volume/defaults/main.yml
@@ -1,2 +1,0 @@
----
-test_mountpoint: "/mnt/gbench/"

--- a/ansible-playbook-base/roles/mount-gluster-volume/defaults/main.yml
+++ b/ansible-playbook-base/roles/mount-gluster-volume/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+test_mountpoint: "/mnt/gbench/"

--- a/ansible-playbook-base/roles/mount-gluster-volume/tasks/main.yml
+++ b/ansible-playbook-base/roles/mount-gluster-volume/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+# Role mounts the gluster volume on play hosts
+# TODO:
+#   - We need to mount FUSE/NFS/Other and role should adapt to the type
+
+- name: Include volume configuration
+  include_vars:
+    file: "{{ vc_definition }}"
+  run_once: true
+
+- name: Create mountpoint
+  file:
+    path: "{{ test_mountpoint }}"
+    state: directory
+
+- name: Mount the Gluster filesystem
+  mount:
+    path: "{{ test_mountpoint }}"
+    src: "{{ hostvars[groups['servers'][0]]['glusterip'] }}:{{ volume }}"
+    fstype: glusterfs
+    state: mounted

--- a/ansible-playbook-base/roles/mount-gluster-volume/tasks/main.yml
+++ b/ansible-playbook-base/roles/mount-gluster-volume/tasks/main.yml
@@ -10,12 +10,12 @@
 
 - name: Create mountpoint
   file:
-    path: "{{ test_mountpoint }}"
+    path: "{{ gbench_client_mountpoint }}"
     state: directory
 
 - name: Mount the Gluster filesystem
   mount:
-    path: "{{ test_mountpoint }}"
+    path: "{{ gbench_client_mountpoint }}"
     src: "{{ hostvars[groups['servers'][0]]['glusterip'] }}:{{ volume }}"
     fstype: glusterfs
     state: mounted

--- a/ansible-playbook-base/roles/passwdless-ssh-mesh/tasks/main.yml
+++ b/ansible-playbook-base/roles/passwdless-ssh-mesh/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+# This task creates ssh keys on each host, or uses existing keys and populates
+# the authorized keys on other hosts (in scope of the play) to trust the
+# existing or generated key.
+
+- name: Generate ssh key for ansible user
+  user:
+    name: "{{ ansible_user }}"
+    generate_ssh_key: yes
+    ssh_key_file: .ssh/id_rsa
+
+- name: Gather ansible users ssh public key
+  shell: cat ~/.ssh/id_rsa.pub
+  register: user_ssh_pubkey
+
+- name: Authorize ansible user on all hosts
+  authorized_key:
+    user: "{{ ansible_user }}"
+    key: "{{ hostvars[item]['user_ssh_pubkey']['stdout'] }}"
+  with_items: "{{ play_hosts }}"
+
+- name: Gather hosts ssh public key for Gluster IP
+  shell: ssh-keyscan -t rsa {{ glusterip }}
+  register: host_ssh_gip_pubkey
+
+- name: Trust all play hosts ssh Gluster IP
+  known_hosts:
+    state: present
+    name: "{{ hostvars[item]['glusterip'] }}"
+    key: "{{ hostvars[item]['host_ssh_gip_pubkey']['stdout'] }}"
+  with_items: "{{ play_hosts }}"
+
+- name: Gather hosts ssh public key for hostname
+  shell: ssh-keyscan -t rsa {{ inventory_hostname }}
+  register: host_ssh_pubkey
+
+- name: Trust all play hosts ssh by hostname
+  known_hosts:
+    state: present
+    name: "{{ hostvars[item]['inventory_hostname'] }}"
+    key: "{{ hostvars[item]['host_ssh_pubkey']['stdout'] }}"
+  with_items: "{{ play_hosts }}"

--- a/ansible-playbook-base/roles/perftest-fio/defaults/main.yml
+++ b/ansible-playbook-base/roles/perftest-fio/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+fio_deps:
+  - zlib-devel
+  - libaio
+  - fio
+fio_json_output: /tmp/fio_test_out.json
+fio_working_directory: /tmp/fio/

--- a/ansible-playbook-base/roles/perftest-fio/tasks/cleanup_cache.yml
+++ b/ansible-playbook-base/roles/perftest-fio/tasks/cleanup_cache.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Issue sync
+  command: sync
+
+- name: Issue drop cache
+  shell: echo 3 > /proc/sys/vm/drop_caches

--- a/ansible-playbook-base/roles/perftest-fio/tasks/main.yml
+++ b/ansible-playbook-base/roles/perftest-fio/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Display test variables
+  run_once: true
+  debug:
+    msg: "NOT-IMPLEMENTED: FIO Test variable {{ test_vars }}"

--- a/ansible-playbook-base/roles/perftest-fio/tasks/main.yml
+++ b/ansible-playbook-base/roles/perftest-fio/tasks/main.yml
@@ -1,6 +1,87 @@
 ---
 
+# Informational task
 - name: Display test variables
   run_once: true
   debug:
-    msg: "NOT-IMPLEMENTED: FIO Test variable {{ test_vars }}"
+    msg: "FIO Test variable {{ test_vars }}"
+
+# Install fio and dependencies
+- name: Installing fio and dependent packages
+  package:
+    name: "{{ fio_pkg_name }}"
+    state: present
+  loop: "{{ fio_deps|flatten(levels=1) }}"
+  loop_control:
+      loop_var: fio_pkg_name
+  when:
+    - inventory_hostname in groups['clients']
+
+# Ensure directory runtime structure is present
+- name: Create fio working directory
+  file:
+    path: "{{ fio_working_directory }}"
+    state: directory
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+# Build client list and start fio deamons on clients for the test
+- name: Unset FIO client list
+  set_fact:
+    fioclientlist: ""
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+- name: Select clients to participate in FIO test
+  set_fact:
+    fioclientlist: "{{ fioclientlist  | default('') }} {{ hostvars[item_client]['inventory_hostname'] }}"
+  loop: "{{ groups['clients'] }}"
+  loop_control:
+    index_var: ccount_idx
+    loop_var: item_client
+  when:
+    - ccount_idx < test_vars.client_count
+    - inventory_hostname == groups['clients'][0]
+
+- name: Remove clients list file
+  file:
+    path: {{ fio_working_directory }}clients.list
+    state: absent
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+- name: Create client list for FIO test
+  shell: echo "{{ hostvars[item_client]['inventory_hostname'] }}" >> {{ fio_working_directory }}clients.list
+  loop: "{{ groups['clients'] }}"
+  loop_control:
+    index_var: ccount_idx
+    loop_var: item_client
+  when:
+    - item_client in hostvars[groups['clients'][0]]['fioclientlist']
+    - inventory_hostname == groups['clients'][0]
+
+- name: Start FIO server on selected clients
+  shell: fio --server --daemonize=/var/run/fio-svr.pid
+  when:
+    - inventory_hostname in groups['clients']
+    - inventory_hostname in hostvars[groups['clients'][0]]['fioclientlist']
+
+# Prepare the test.ini file
+- name: Prepare test.ini for FIO run
+  shell: echo "{{ test_vars.testinispec }}" > {{ fio_working_directory }}test.ini
+  loop: "{{ groups['clients'] }}"
+  loop_control:
+    index_var: ccount_idx
+    loop_var: item_client
+  when:
+    - item_client in hostvars[groups['clients'][0]]['fioclientlist']
+    - inventory_hostname == groups['clients'][0]
+
+# Execute required iterations of the test
+- name: Executing an iteration of FIO
+  include_role:
+    name: perftest-fio
+    tasks_from: test
+  loop: "{{ range(0, test_vars.iterations)|list }}"
+  loop_control:
+    index_var: fio_iter_index

--- a/ansible-playbook-base/roles/perftest-fio/tasks/test.yml
+++ b/ansible-playbook-base/roles/perftest-fio/tasks/test.yml
@@ -1,0 +1,52 @@
+---
+
+- name: Cleanup pre-start of test (conditional)
+  shell: rm -rf {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}fio/*
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname == groups['clients'][0]
+    - test_vars.cleanup_pre and fio_iter_index == 0
+
+- name: Cleanup client cache
+  include: cleanup_cache.yml
+  when:
+    - test_vars.cleanclientcache
+    - inventory_hostname in groups['clients']
+
+- name: Cleanup server cache
+  include: cleanup_cache.yml
+  when:
+    - test_vars.cleanservercache
+    - inventory_hostname in groups['servers']
+
+- name: Run a FIO test
+  shell: fio {{ fio_working_directory }}/test.ini --output-format=json --client={{ fio_working_directory }}/clients.list > "{{ fio_json_output }}"
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+- name: Retrieve test results
+  fetch:
+    src: "{{ fio_json_output }}"
+    dest: "/tmp/fio-test-{{ test_vars.testname }}-iteration-{{ fio_iter_index }}.json"
+    flat: yes
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+- name: Cleanup in between tests (conditional)
+  shell: rm -rf {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}fio/*
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname == groups['clients'][0]
+    - test_vars.cleanup_between and fio_iter_index != test_vars.iterations - 1
+
+- name: Cleanup post last iteration of test (conditional)
+  shell: rm -rf {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}fio/*
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname == groups['clients'][0]
+    - test_vars.cleanup_last and fio_iter_index == test_vars.iterations - 1

--- a/ansible-playbook-base/roles/perftest-smallfile/defaults/main.yml
+++ b/ansible-playbook-base/roles/perftest-smallfile/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+smallfile_clone_location: /root/tests/smallfile/
+smallfile_repo: https://github.com/bengland2/smallfile.git
+smallfile_deps:
+  - git
+  - python
+smallfile_json_output: /tmp/smallfile_test_out.json

--- a/ansible-playbook-base/roles/perftest-smallfile/tasks/cleanup_cache.yml
+++ b/ansible-playbook-base/roles/perftest-smallfile/tasks/cleanup_cache.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Issue sync
+  command: sync
+
+- name: Issue drop cache
+  shell: echo 3 > /proc/sys/vm/drop_caches

--- a/ansible-playbook-base/roles/perftest-smallfile/tasks/main.yml
+++ b/ansible-playbook-base/roles/perftest-smallfile/tasks/main.yml
@@ -1,0 +1,86 @@
+---
+
+# Debug task
+- name: Display test variables
+  run_once: true
+  debug:
+    msg: "Smallfile Test variable {{ test_vars }}"
+
+# Install tool dependencies
+- name: Check for smallfile executable
+  stat:
+    path: "{{ smallfile_clone_location }}/.git"
+  register: smallfile_present
+  when:
+    - inventory_hostname in groups['clients']
+
+## Install smallfile and dependencies if not present
+- when:
+    - inventory_hostname in groups['clients']
+    - smallfile_present.stat.exists == false
+  block:
+  - name: Installing smallfile dependent packages
+    package:
+      name: "{{ smallfile_pkg_name }}"
+      state: present
+    loop: "{{ smallfile_deps|flatten(levels=1) }}"
+    loop_control:
+      loop_var: smallfile_pkg_name
+
+  - name: clone smallfile
+    git:
+      repo: "{{ smallfile_repo }}"
+      dest: "{{ smallfile_clone_location }}"
+
+# Build common variables for test
+- name: Build client environment variable for smallfile
+  set_fact:
+    clientlist: "{{ hostvars[inventory_hostname]['glusterip'] }}"
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+- name: Expand client environment variable for smallfile
+  set_fact:
+    clientlist: "{{ clientlist }},{{ hostvars[ccount]['glusterip'] }}"
+  loop: "{{ groups['clients'] }}"
+  loop_control:
+    index_var: ccount_idx
+    loop_var: ccount
+  when:
+    - inventory_hostname == groups['clients'][0]
+    - ccount != inventory_hostname
+    - ccount_idx <= test_vars.client_count - 1
+    - test_vars.client_count > 1
+
+# Debug task
+- name: Display client list
+  debug:
+    msg: "echo {{ hostvars[inventory_hostname]['clientlist'] }}"
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+# Ensure directory runtime structure is present
+- name: Check for smallfile execution top directory
+  stat:
+    path: "{{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile"
+  register: smallfile_topdir
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+- when:
+  - inventory_hostname == groups['clients'][0]
+  - smallfile_topdir.stat.exists == false
+  block:
+  - name: Create smallfile execution top directory
+    file:
+      path: "{{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile"
+      state: directory
+
+# Execute required iterations of the test
+- name: Executing an iteration of Smallfile
+  include_role:
+    name: perftest-smallfile
+    tasks_from: test
+  loop: "{{ range(0, test_vars.iterations)|list }}"
+  loop_control:
+    index_var: smallfile_iter_index

--- a/ansible-playbook-base/roles/perftest-smallfile/tasks/test.yml
+++ b/ansible-playbook-base/roles/perftest-smallfile/tasks/test.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Cleanup pre-start of test (conditional)
+  shell: rm -rf {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile/*
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname == groups['clients'][0]
+    - test_vars.cleanup_pre and smallfile_iter_index == 0
+
 - name: Cleanup client cache
   include: cleanup_cache.yml
   when:
@@ -17,14 +25,6 @@
     msg: "Running: {{ smallfile_clone_location }}/smallfile_cli.py --operation {{ test_vars.operation|quote }} --threads {{ test_vars.threads|quote }} --file-size {{ test_vars.filesize|quote }} --files {{ test_vars.files|quote }} --top {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile --host-set {{ hostvars[inventory_hostname]['clientlist'] }} --output-json {{ smallfile_json_output }}"
   when:
     - inventory_hostname == groups['clients'][0]
-
-- name: Cleanup pre-start of test (conditional)
-  shell: rm -rf {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile/*
-  args:
-    executable: /bin/bash
-  when:
-    - inventory_hostname == groups['clients'][0]
-    - test_vars.cleanup_pre and smallfile_iter_index == 0
 
 - name: Run a smallfile test
   shell: python {{ smallfile_clone_location }}/smallfile_cli.py --operation {{ test_vars.operation|quote }} --threads {{ test_vars.threads|quote }} --file-size {{ test_vars.filesize|quote }} --files {{ test_vars.files|quote }} --top {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile --host-set {{ hostvars[inventory_hostname]['clientlist'] }} --output-json {{ smallfile_json_output }}

--- a/ansible-playbook-base/roles/perftest-smallfile/tasks/test.yml
+++ b/ansible-playbook-base/roles/perftest-smallfile/tasks/test.yml
@@ -1,0 +1,58 @@
+---
+
+- name: Cleanup client cache
+  include: cleanup_cache.yml
+  when:
+    - test_vars.cleanclientcache
+    - inventory_hostname in groups['clients']
+
+- name: Cleanup server cache
+  include: cleanup_cache.yml
+  when:
+    - test_vars.cleanservercache
+    - inventory_hostname in groups['servers']
+
+- name: Echo the test variables
+  debug:
+    msg: "Running: {{ smallfile_clone_location }}/smallfile_cli.py --operation {{ test_vars.operation|quote }} --threads {{ test_vars.threads|quote }} --file-size {{ test_vars.filesize|quote }} --files {{ test_vars.files|quote }} --top {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile --host-set {{ hostvars[inventory_hostname]['clientlist'] }} --output-json {{ smallfile_json_output }}"
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+- name: Cleanup pre-start of test (conditional)
+  shell: rm -rf {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile/*
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname == groups['clients'][0]
+    - test_vars.cleanup_pre and smallfile_iter_index == 0
+
+- name: Run a smallfile test
+  shell: python {{ smallfile_clone_location }}/smallfile_cli.py --operation {{ test_vars.operation|quote }} --threads {{ test_vars.threads|quote }} --file-size {{ test_vars.filesize|quote }} --files {{ test_vars.files|quote }} --top {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile --host-set {{ hostvars[inventory_hostname]['clientlist'] }} --output-json {{ smallfile_json_output }}
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+- name: Retrieve test results
+  fetch:
+    src: "{{ smallfile_json_output }}"
+    dest: "/tmp/smallfile-test-{{ test_vars.testname }}-iteration-{{ smallfile_iter_index }}.json"
+    flat: yes
+  when:
+    - inventory_hostname == groups['clients'][0]
+
+- name: Cleanup in between tests (conditional)
+  shell: rm -rf {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile/*
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname == groups['clients'][0]
+    - test_vars.cleanup_between and smallfile_iter_index != test_vars.iterations - 1
+
+- name: Cleanup post last iteration of test (conditional)
+  shell: rm -rf {{ hostvars[inventory_hostname]['gbench_client_mountpoint'] }}smallfile/*
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname == groups['clients'][0]
+    - test_vars.cleanup_last and smallfile_iter_index == test_vars.iterations - 1

--- a/ansible-playbook-base/roles/run-bench-tests/tasks/main.yml
+++ b/ansible-playbook-base/roles/run-bench-tests/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# Role runs through the bench test requests and executes each test
+# TODO:
+#   -
+
+- name: Include bench tests to run
+  include_vars:
+    file: "{{ bt_definition }}"
+  run_once: true
+
+# Debug related
+- name: Display test variables
+  delegate_to: localhost
+  run_once: true
+  debug:
+    msg: "Test variable {{ bench_test }}"
+  with_items: "{{ benchmarks }}"
+  loop_control:
+    loop_var: bench_test
+
+- name: Execute bench test
+  include_role:
+    name: "perftest-{{ bench_test.type }}"
+  vars:
+    test_vars: "{{ bench_test }}"
+  loop: "{{ benchmarks|flatten(levels=1) }}"
+  loop_control:
+    loop_var: bench_test

--- a/ansible-playbook-base/site.yml
+++ b/ansible-playbook-base/site.yml
@@ -18,6 +18,14 @@
   tags:
     - storagesetup
 
+- name: Cleanup gluster mounts
+  hosts: clients
+  gather_facts: false
+  roles:
+    - cleanup-gluster-clients
+  tags:
+    - glustervolume
+
 - name: Cleanup Gluster volume
   hosts: servers
   gather_facts: false
@@ -64,3 +72,10 @@
     - create-gluster-volume
   tags:
     - glustervolume
+
+- name: Mount Gluster volume
+  hosts: clients
+  gather_facts: false
+  roles:
+    - mount-gluster-volume
+

--- a/ansible-playbook-base/site.yml
+++ b/ansible-playbook-base/site.yml
@@ -79,3 +79,9 @@
   roles:
     - mount-gluster-volume
 
+- name: Enable SSH trust across hosts
+  hosts: all
+  gather_facts: false
+  roles:
+    - passwdless-ssh-mesh
+

--- a/ansible-playbook-base/site.yml
+++ b/ansible-playbook-base/site.yml
@@ -85,3 +85,9 @@
   roles:
     - passwdless-ssh-mesh
 
+- name: Run benchmark tests
+  hosts: all
+  gather_facts: false
+  roles:
+    - run-bench-tests
+

--- a/bench-tests/bt-0000-0001.yml
+++ b/bench-tests/bt-0000-0001.yml
@@ -1,0 +1,53 @@
+---
+benchmarks:
+  - {
+      testname: benchmark1,
+      type: smallfile,
+      iterations: 1,
+      cleanclientcache: yes,
+      cleanservercache: yes,
+      client_count: 2,
+      operation: create,
+      threads: 2,
+      filesize: 4,
+      files: 100,
+      response_times: no,
+      cleanup_pre: yes,
+      cleanup_between: no,
+      cleanup_last: no,
+      output-json: yes
+    }
+  - {
+      testname: benchmark2,
+      type: smallfile,
+      iterations: 2,
+      cleanclientcache: yes,
+      cleanservercache: yes,
+      client_count: 2,
+      operation: read,
+      threads: 2,
+      filesize: 4,
+      files: 100,
+      response_times: no,
+      cleanup_pre: no,
+      cleanup_between: no,
+      cleanup_last: no,
+      output-json: yes
+    }
+  - {
+      testname: benchmark3,
+      type: smallfile,
+      iterations: 1,
+      cleanclientcache: yes,
+      cleanservercache: yes,
+      client_count: 2,
+      operation: ls-l,
+      threads: 2,
+      filesize: 4,
+      files: 100,
+      response_times: no,
+      cleanup_pre: no,
+      cleanup_between: no,
+      cleanup_last: no,
+      output-json: yes
+    }

--- a/bench-tests/bt-0000-0001.yml
+++ b/bench-tests/bt-0000-0001.yml
@@ -1,16 +1,16 @@
 ---
 benchmarks:
   - {
-      testname: benchmark1,
+      testname: smallfile-benchmark-1,
       type: smallfile,
-      iterations: 1,
+      iterations: 3,
       cleanclientcache: yes,
       cleanservercache: yes,
-      client_count: 2,
+      client_count: 4,
       operation: create,
-      threads: 2,
-      filesize: 4,
-      files: 100,
+      threads: 8,
+      filesize: 64,
+      files: 10000,
       response_times: no,
       cleanup_pre: yes,
       cleanup_between: no,
@@ -18,16 +18,16 @@ benchmarks:
       output-json: yes
     }
   - {
-      testname: benchmark2,
+      testname: smallfile-benchmark-2,
       type: smallfile,
-      iterations: 2,
+      iterations: 3,
       cleanclientcache: yes,
       cleanservercache: yes,
-      client_count: 2,
+      client_count: 4,
       operation: read,
-      threads: 2,
-      filesize: 4,
-      files: 100,
+      threads: 8,
+      filesize: 64,
+      files: 10000,
       response_times: no,
       cleanup_pre: no,
       cleanup_between: no,
@@ -35,19 +35,19 @@ benchmarks:
       output-json: yes
     }
   - {
-      testname: benchmark3,
+      testname: smalfile-benchmark-3,
       type: smallfile,
-      iterations: 1,
+      iterations: 3,
       cleanclientcache: yes,
       cleanservercache: yes,
-      client_count: 2,
+      client_count: 4,
       operation: ls-l,
-      threads: 2,
-      filesize: 4,
-      files: 100,
+      threads: 8,
+      filesize: 64,
+      files: 10000,
       response_times: no,
       cleanup_pre: no,
       cleanup_between: no,
-      cleanup_last: no,
+      cleanup_last: yes,
       output-json: yes
     }

--- a/bench-tests/bt-0000-0002.yml
+++ b/bench-tests/bt-0000-0002.yml
@@ -1,0 +1,104 @@
+---
+benchmarks:
+  - {
+      testname: fio-benchmark-1,
+      type: fio,
+      iterations: 3,
+      cleanclientcache: yes,
+      cleanservercache: yes,
+      client_count: 4,
+      cleanup_pre: yes,
+      cleanup_between: yes,
+      cleanup_last: yes,
+      testinispec: "[global]\n
+                    rw=write\n
+                    fsync_on_close=1\n
+                    size=4g\n
+                    bs=64k\n
+                    openfiles=1\n
+                    startdelay=0\n
+                    ioengine=sync\n
+\n
+                    [write]\n
+                    directory=/mnt/gbench\n
+                    nrfiles=1\n
+                    filename_format=f.$jobnum.$filenum\n
+                    numjobs=8"
+    }
+  - {
+      testname: fio-benchmark-2,
+      type: fio,
+      iterations: 3,
+      cleanclientcache: yes,
+      cleanservercache: yes,
+      client_count: 4,
+      cleanup_pre: yes,
+      cleanup_between: yes,
+      cleanup_last: yes,
+      testinispec: "[global]\n
+                    rw=read\n
+                    fsync_on_close=1\n
+                    size=4g\n
+                    bs=64k\n
+                    openfiles=1\n
+                    startdelay=0\n
+                    ioengine=sync\n
+\n
+                    [write]\n
+                    directory=/mnt/gbench\n
+                    nrfiles=1\n
+                    filename_format=f.$jobnum.$filenum\n
+                    numjobs=8"
+    }
+  - {
+      testname: fio-benchmark-3,
+      type: fio,
+      iterations: 3,
+      cleanclientcache: yes,
+      cleanservercache: yes,
+      client_count: 4,
+      cleanup_pre: yes,
+      cleanup_between: yes,
+      cleanup_last: yes,
+      testinispec: "[global]\n
+                    rw=randread\n
+                    fsync_on_close=1\n
+                    io_size=1g\n
+                    size=4g\n
+                    bs=64k\n
+                    openfiles=1\n
+                    startdelay=0\n
+                    ioengine=sync\n
+\n
+                    [randwrite]\n
+                    directory=/mnt/gbench\n
+                    nrfiles=1\n
+                    filename_format=f.$jobnum.$filenum\n
+                    numjobs=8"
+    }
+  - {
+      testname: fio-benchmark-4,
+      type: fio,
+      iterations: 3,
+      cleanclientcache: yes,
+      cleanservercache: yes,
+      client_count: 4,
+      cleanup_pre: yes,
+      cleanup_between: yes,
+      cleanup_last: yes,
+      testinispec: "[global]\n
+                    rw=randwrite\n
+                    io_size=1g\n
+                    fsync_on_close=1\n
+                    size=4g\n
+                    bs=64k\n
+                    openfiles=1\n
+                    startdelay=0\n
+                    ioengine=sync\n
+\n
+                    [write]\n
+                    directory=/gluster-mount\n
+                    nrfiles=1\n
+                    filename_format=f.$jobnum.$filenum\n
+                    numjobs=8"\n
+    }

--- a/gluster-sources/upstream-3.12.14.yml
+++ b/gluster-sources/upstream-3.12.14.yml
@@ -1,0 +1,6 @@
+# This file defines variables to use upstream gluster 3.10.3 bits
+#
+
+repository_type: upstream
+gluster_major_release: "3.12"
+gluster_minor_release: "14-1"

--- a/setup-profiles/sp-0000-0010/group_vars/all
+++ b/setup-profiles/sp-0000-0010/group_vars/all
@@ -13,3 +13,5 @@ ipoib_netmask: 255.255.255.0
 ipoib_use_gateway: yes
 ipoib_gateway: em1
 
+# Mountpoint for clients
+gbench_client_mountpoint: "/mnt/gbench/"

--- a/setup-profiles/template/group_vars/all
+++ b/setup-profiles/template/group_vars/all
@@ -25,6 +25,12 @@
 # Each host needs to have a 'glusteripv4' variable defined, in its host specific
 # variable file
 
+# ---- Gluster client mountpoint variable ----
+# *OPTIONAL*
+# Each client host can provide a mountpoint, where created Gluster volumes would
+# be mounted for the various tests. If unspecified this will default to the
+# existing roles default variables. The variable is named 'test_mountpoint'
+
 # ---- IB over IP configuration variables ----
 # *OPTIONAL*
 # If the hosts comes with Infiniband gear and you would like gbench to setup

--- a/setup-profiles/template/group_vars/all
+++ b/setup-profiles/template/group_vars/all
@@ -26,10 +26,11 @@
 # variable file
 
 # ---- Gluster client mountpoint variable ----
-# *OPTIONAL*
-# Each client host can provide a mountpoint, where created Gluster volumes would
-# be mounted for the various tests. If unspecified this will default to the
-# existing roles default variables. The variable is named 'test_mountpoint'
+# *NEEDED*
+# Each client host must provide a mountpoint, where created Gluster volumes
+# would be mounted for the various tests. If unspecified this will default to
+# the existing roles default variables. The variable is named
+# 'gbench_client_mountpoint'
 
 # ---- IB over IP configuration variables ----
 # *OPTIONAL*


### PR DESCRIPTION
This PR adds the following abilities,
- Prepare clients with a FUSE mount
- Setup ssh trust servers across the test setup
- Add ability to parse and run a set of benchmark tests
- Add ability to perform smallfile tests using given yml definition
- Add ability to perform FIO tests using given yml definition