### PR TITLE
Added Gluster nightly and downstream repo support

### DIFF
--- a/ansible-playbook-base/roles/common/tasks/main.yml
+++ b/ansible-playbook-base/roles/common/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - include: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}.yml"
+    - "{% if ansible_distribution | lower == 'centos' or ansible_distribution | lower == 'redhat'  %}centos.yml{% else %}{{ ansible_distribution | lower }}.yml{% endif %}"
   tags:
     - packagesall
 

--- a/ansible-playbook-base/roles/install-repos/tasks/centos.yml
+++ b/ansible-playbook-base/roles/install-repos/tasks/centos.yml
@@ -46,3 +46,14 @@
   when:
     - repository_type|lower == "specific"
 
+# Install nightly/downstream Gluster bits provided on the host
+- name: Install nightly/downstream gluster bits
+  yum_repository:
+    name: "Gluster-{{ repository_type }}-{{ repo_name }}"
+    description: "User {{ repository_type }} Gluster repository"
+    baseurl: "{{ repo_baseurl }}"
+    gpgcheck: "no"
+    enabled: yes
+    state: present
+  when:
+    - repository_type|lower == "nightly" or repository_type|lower == "downstream"

--- a/ansible-playbook-base/roles/install-repos/tasks/main.yml
+++ b/ansible-playbook-base/roles/install-repos/tasks/main.yml
@@ -10,7 +10,7 @@
   vars:
     repo_details: "{{ server_repo }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}.yml"
+    - "{% if ansible_distribution | lower == 'centos' or ansible_distribution | lower == 'redhat'  %}centos.yml{% else %}{{ ansible_distribution | lower }}.yml{% endif %}"
   when: inventory_hostname in groups['servers']
   tags:
     - packagesall
@@ -21,7 +21,7 @@
   vars:
     repo_details: "{{ client_repo }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}.yml"
+    - "{% if ansible_distribution | lower == 'centos' or ansible_distribution | lower == 'redhat'  %}centos.yml{% else %}{{ ansible_distribution | lower }}.yml{% endif %}"
   when: inventory_hostname in groups['clients']
   tags:
     - packagesall

--- a/ansible-playbook-base/roles/prepare-gluster-client/tasks/centos.yml
+++ b/ansible-playbook-base/roles/prepare-gluster-client/tasks/centos.yml
@@ -15,9 +15,27 @@
   yum:
     name: "glusterfs-{{ gluster_major_release }}.{{ gluster_minor_release }}.el{{ ansible_distribution_major_version }}"
     state: present
+  when:
+    - repository_type|lower == "upstream" or repository_type|lower == "upstream-qa" or repository_type|lower == "specific"
+
+- name: Install gluster server specific/nightly/downstream bits
+  yum:
+    name: "glusterfs"
+    state: present
+  when:
+    - repository_type|lower == "nightly" or repository_type|lower == "downstream"
 
 # TODO: the manner to get el7 should be nicer,
 - name: Install glusterfs-fuse package
   yum:
     name: "glusterfs-fuse-{{ gluster_major_release }}.{{ gluster_minor_release }}.el{{ ansible_distribution_major_version }}"
     state: present
+  when:
+    - repository_type|lower == "upstream" or repository_type|lower == "upstream-qa" or repository_type|lower == "specific"
+
+- name: Install glusterfs-fuse package
+  yum:
+    name: "glusterfs-fuse"
+    state: present
+  when:
+    - repository_type|lower == "nightly" or repository_type|lower == "downstream"

--- a/ansible-playbook-base/roles/prepare-gluster-client/tasks/main.yml
+++ b/ansible-playbook-base/roles/prepare-gluster-client/tasks/main.yml
@@ -11,7 +11,7 @@
   vars:
     repo_details: "{{ client_repo }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}.yml"
+    - "{% if ansible_distribution | lower == 'centos' or ansible_distribution | lower == 'redhat'  %}centos.yml{% else %}{{ ansible_distribution | lower }}.yml{% endif %}"
   tags:
     - packagesall
     - packagesclient

--- a/ansible-playbook-base/roles/prepare-gluster-server/tasks/centos.yml
+++ b/ansible-playbook-base/roles/prepare-gluster-server/tasks/centos.yml
@@ -18,6 +18,18 @@
   tags:
     - packagesall
     - packagesserver
+  when:
+    - repository_type|lower == "upstream" or repository_type|lower == "upstream-qa" or repository_type|lower == "specific"
+
+- name: Install gluster server specific/nightly/downstream bits
+  yum:
+    name: "glusterfs-server"
+    state: present
+  tags:
+    - packagesall
+    - packagesserver
+  when:
+    - repository_type|lower == "nightly" or repository_type|lower == "downstream"
 
 - name: Enable glusterd service on hosts
   systemd:

--- a/ansible-playbook-base/roles/prepare-gluster-server/tasks/main.yml
+++ b/ansible-playbook-base/roles/prepare-gluster-server/tasks/main.yml
@@ -11,7 +11,7 @@
   vars:
     repo_details: "{{ server_repo }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}.yml"
+    - "{% if ansible_distribution | lower == 'centos' or ansible_distribution | lower == 'redhat'  %}centos.yml{% else %}{{ ansible_distribution | lower }}.yml{% endif %}"
 
 - name: Peer probe the cluster
   include: peerprobe.yml

--- a/gluster-sources/downstream.yml
+++ b/gluster-sources/downstream.yml
@@ -1,0 +1,5 @@
+repository_type: downstream
+repo_name: "downstream_gluster"
+repo_description: "This repo downstream nightly builds of gluster"
+repo_baseurl: "http://nowhere.notnow.com/builds"
+repo_gpgcheck: "no"

--- a/gluster-sources/nightly.yml
+++ b/gluster-sources/nightly.yml
@@ -1,0 +1,5 @@
+repository_type: nightly
+repo_name: "nightly_gluster"
+repo_description: "This repo stores nightly builds of gluster"
+repo_baseurl: "http://artifacts.ci.centos.org/gluster/nightly/master/$releasever/$basearch"
+repo_gpgcheck: "no"


### PR DESCRIPTION
Currently, hacks are required to use Gluster nightly or downstream bits.
This PR will add support for the above.

Signed-off-by: rohan47 <rohanrgupta1996@gmail.com>